### PR TITLE
Merging pgModeler changes

### DIFF
--- a/.github/workflows/build-nurs6293-desktop.yml
+++ b/.github/workflows/build-nurs6293-desktop.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   docker-build:
-    runs-on: macos-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
@@ -26,6 +26,11 @@ jobs:
         
       - name: Pull artifacts
         run: cd nurs6293_desktop && ./pull_artifacts.sh
+      
+      - name: Pull pgModeler binaries
+        run: gh release download v1.1 --repo Andrew0Hill/pgmodeler_binaries --pattern '*.tar.gz' --dir artifacts
+        env:
+          GH_TOKEN: ${{ secrets.BINARY_REPO_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v6

--- a/nurs6293_desktop/Dockerfile
+++ b/nurs6293_desktop/Dockerfile
@@ -26,6 +26,11 @@ RUN mv eclipse/ birt/
 ARG DBEAVER_ARM64_BINARY="dbeaver-ce-latest-linux.gtk.aarch64-nojdk.tar.gz"
 ADD "artifacts/${DBEAVER_ARM64_BINARY}" .
 
+# Install pgModeler (AMD64)
+ARG PGMODELER_ARM64_BINARY="pgmodeler_arm64.tar.gz"
+ADD "artifacts/${PGMODELER_ARM64_BINARY}" .
+RUN cp -r pgmodeler_arm64/* /usr/local/
+
 # The build-amd64 builds the AMD image.
 FROM linuxserver/webtop:debian-xfce@sha256:6edbb9e46f111375018413fb6a8cd1345e67ab7ebbf1633fe4c03b025bedd57d AS build-amd64
 
@@ -54,6 +59,11 @@ RUN mv eclipse/ birt/
 ARG DBEAVER_AMD64_BINARY="dbeaver-ce-latest-linux.gtk.x86_64-nojdk.tar.gz"
 ADD "artifacts/${DBEAVER_AMD64_BINARY}" .
 
+# Install pgModeler (AMD64)
+ARG PGMODELER_AMD64_BINARY="pgmodeler_amd64.tar.gz"
+ADD "artifacts/${PGMODELER_AMD64_BINARY}" .
+RUN cp -r pgmodeler_amd64/* /usr/local/
+
 # At this stage, all architecture-specific configuration is done. 
 # We can now perform a single set of steps for both architectures to complete the setup.
 FROM build-${TARGETARCH} AS build-common
@@ -64,14 +74,6 @@ ARG JDBC_POSTGRES_JAR="postgresql-42.7.4.jar"
 COPY "artifacts/${JDBC_POSTGRES_JAR}" "drivers/${JDBC_POSTGRES_JAR}"
 # What a convenient location!
 RUN cp "drivers/${JDBC_POSTGRES_JAR}" "/programs/birt/plugins/org.eclipse.birt.report.data.oda.jdbc_4.16.0.v202406141054/drivers/${JDBC_POSTGRES_JAR}"
-
-# Install pgModeler from source. Since we are not using a binary, we don't need separate commands for ARM64 vs AMD64.
-COPY artifacts/pgmodeler ./pgmodeler
-COPY build_pgmodeler.sh ./pgmodeler/build_pgmodeler.sh
-RUN cd ./pgmodeler && \
-    chmod +x ./build_pgmodeler.sh && \
-    ./build_pgmodeler.sh && \
-    rm ./build_pgmodeler.sh
 
 # Configure desktop entries for each program.
 # These entries allow the applications to show up in the app menu.

--- a/nurs6293_desktop/Dockerfile
+++ b/nurs6293_desktop/Dockerfile
@@ -28,8 +28,8 @@ ADD "artifacts/${DBEAVER_ARM64_BINARY}" .
 
 # Install pgModeler (AMD64)
 ARG PGMODELER_ARM64_BINARY="pgmodeler_arm64.tar.gz"
-ADD "artifacts/${PGMODELER_ARM64_BINARY}" .
-RUN cp -r pgmodeler_arm64/* /usr/local/
+ADD "artifacts/${PGMODELER_ARM64_BINARY}" /
+#RUN cd /pgmodeler_src && make install && cd / && rm -rf pgmodeler_src
 
 # The build-amd64 builds the AMD image.
 FROM linuxserver/webtop:debian-xfce@sha256:6edbb9e46f111375018413fb6a8cd1345e67ab7ebbf1633fe4c03b025bedd57d AS build-amd64
@@ -61,8 +61,8 @@ ADD "artifacts/${DBEAVER_AMD64_BINARY}" .
 
 # Install pgModeler (AMD64)
 ARG PGMODELER_AMD64_BINARY="pgmodeler_amd64.tar.gz"
-ADD "artifacts/${PGMODELER_AMD64_BINARY}" .
-RUN cp -r pgmodeler_amd64/* /usr/local/
+ADD "artifacts/${PGMODELER_AMD64_BINARY}" /
+#RUN cd /pgmodeler_src && make install && cd / && rm -rf pgmodeler_src
 
 # At this stage, all architecture-specific configuration is done. 
 # We can now perform a single set of steps for both architectures to complete the setup.

--- a/nurs6293_desktop/config/pgmodeler.desktop
+++ b/nurs6293_desktop/config/pgmodeler.desktop
@@ -2,6 +2,6 @@
 Type=Application
 Name=pgModeler
 Comment=Data Modeler
-Exec=pgmodeler
-Icon=/programs/pgmodeler/assets/conf/pgmodeler_logo.png
+Exec=/programs/pgmodeler/bin/pgmodeler
+Icon=/programs/pgmodeler/share/pgmodeler/conf/pgmodeler_logo.png
 Terminal=False

--- a/nurs6293_desktop/pull_artifacts.sh
+++ b/nurs6293_desktop/pull_artifacts.sh
@@ -60,17 +60,7 @@ pull_url "$DBEAVER_BASE_URL/$DBEAVER_AMD64_BINARY" "$OUTPUT_DIR/$DBEAVER_AMD64_B
 echo "Downloaded DBeaver binaries..."
 
 # pgModeler Download
-
-# Clone the repository.
-PGMODELER_PATH="$OUTPUT_DIR/pgmodeler"
-if [[ ! -d $PGMODELER_PATH ]]
-then    
-    git clone -b v1.1.4 --depth 1 https://github.com/pgmodeler/pgmodeler.git $PGMODELER_PATH
-
-    echo "Cloned pgModeler repository..."
-else
-    echo "Skipped cloning '$PGMODELER_PATH', directory already exists..."
-fi
+# TODO: Add this to the build script.
 
 # Done.
 echo "All steps complete."


### PR DESCRIPTION
Potential fix for #21, pre-build pgModeler binaries and use GitHub Actions to download as artifacts before the image build (similar to DBeaver and BIRT). Should reduce build time and allow us to build on GitHub Actions